### PR TITLE
Fix python package publish workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -34,12 +34,13 @@ jobs:
           --debug
         python setup.py sdist
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@717ba43cfbb0387f6ce311b169a825772f54d295
-      with:
-        user: __token__
-        # password: ${{ secrets.PYPI_API_TOKEN }}
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-        skip_existing: true
-        print_hash: true
-        verbose: true
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        twine check dist/*.tar.gz
+        twine upload \
+          --skip-existing \
+          --verbose \
+          --repository testpypi \
+          dist/*.tar.gz

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,12 +3,10 @@
 
 name: Upload Python Package
 
-on: [push]
-
-# on:
-#   push:
-#     branches:
-#       - develop
+on:
+  push:
+    branches:
+      - develop
 
 permissions:
   contents: read
@@ -38,11 +36,10 @@ jobs:
     - name: Publish package
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
         twine check dist/*.tar.gz
         twine upload \
           --skip-existing \
           --verbose \
-          --repository testpypi \
           dist/*.tar.gz

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,10 +3,12 @@
 
 name: Upload Python Package
 
-on:
-  push:
-    branches:
-      - develop
+on: [push]
+
+# on:
+#   push:
+#     branches:
+#       - develop
 
 permissions:
   contents: read
@@ -36,7 +38,7 @@ jobs:
     - name: Publish package
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
       run: |
         twine check dist/*.tar.gz
         twine upload \

--- a/requirements-deploy.txt
+++ b/requirements-deploy.txt
@@ -1,7 +1,7 @@
 # List external packages here
 # Avoid fixed versions
 # # to upload package to PyPi or other package hosts
-# twine>=4.0.1,<5
+twine>=4.0.1,<5
 
 # to parse changelog semver
 semver>=2.13.0,<3


### PR DESCRIPTION
The default Github Action of PyPa does a check of the complete `dist` folder, see https://github.com/pypa/gh-action-pypi-publish/blob/717ba43cfbb0387f6ce311b169a825772f54d295/twine-upload.sh#L54
As the `setup.py sdist` call creates a special distribution and archives the original distribution as `*.tar.gz.org` the twine check is failing.
The fix uses the same calls as in the Github Action of PyPa but limits the check to `dist/*.tar.gz`