### PR TITLE
Add missing common pointer mixin class to common

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,10 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
+## [0.7.1] - 2022-07-29
+### Fixed
+- Add class `CommonPointerMixin` to [`common`](nextion/common.py)
+
 ## [0.7.0] - 2022-07-29
 ### Added
 - Support `Get_pointer_thickness_wid` and `Set_pointer_thickness_wid` by new
@@ -118,8 +122,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - [Example HMI file](examples/everything.HMI) to be used for all examples
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-nextion/compare/0.7.0...develop
+[Unreleased]: https://github.com/brainelectronics/micropython-nextion/compare/0.7.1...develop
 
+[0.7.1]: https://github.com/brainelectronics/micropython-nextion/tree/0.7.1
 [0.7.0]: https://github.com/brainelectronics/micropython-nextion/tree/0.7.0
 [0.6.0]: https://github.com/brainelectronics/micropython-nextion/tree/0.6.0
 [0.5.0]: https://github.com/brainelectronics/micropython-nextion/tree/0.5.0

--- a/nextion/common.py
+++ b/nextion/common.py
@@ -182,6 +182,37 @@ class CommonFontMixin(object):
         return self._nh.recvRetCommandFinished()
 
 
+class CommonPointerMixin(object):
+    """docstring for CommonPointerMixin"""
+    def Get_pointer_thickness_wid(self) -> int:
+        """
+        Get pointer wid attribute of component
+
+        :returns:   The pointer thickness
+        :rtype:     int
+        """
+        cmd = "get {}.wid".format(self.name)
+        self._nh.sendCommand(cmd)
+        sleep(0.1)  # necessary, data might not be available otherwise
+        return self._nh.recvRetNumber()
+
+    def Set_pointer_thickness_wid(self, number: int) -> bool:
+        """
+        Set pointer hig attribute of component
+
+        :param      number:  The pointer thickness
+        :type       number:  int
+
+        :returns:   True on success, false otherwise
+        :rtype:     bool
+        """
+        cmd = "{}.wid={}".format(self.name, number)
+        self._nh.sendCommand(cmd)
+        cmd = "ref {}".format(self.name)
+        self._nh.sendCommand(cmd)
+        return self._nh.recvRetCommandFinished()
+
+
 class CommonPositionMixin(object):
     """docstring for CommonPositionMixin"""
     def Get_place_xcen(self) -> int:


### PR DESCRIPTION
### Fixed
- Add class `CommonPointerMixin` to [`common`](nextion/common.py)