### PR TITLE
Add mip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Connect the MicroPython device to a network (if possible)
 ```python
 import network
 station = network.WLAN(network.STA_IF)
+station.active(True)
 station.connect('SSID', 'PASSWORD')
 station.isconnected()
 ```
@@ -54,6 +55,29 @@ and install this lib on the MicroPython device like this
 ```python
 import upip
 upip.install('micropython-nextion')
+```
+
+### Install package with mip
+
+Starting with v1.20.0 Micropython switched from `upip` to `mip` for package management. Details can be found in [their release notes](https://github.com/micropython/micropython/releases). 
+
+A `package.json` file is provided to facilitate installation using mip.
+
+Connect the MicroPython device to a network (if possible)
+
+```python
+import network
+station = network.WLAN(network.STA_IF)
+station.active(True)
+station.connect('SSID', 'PASSWORD')
+station.isconnected()
+```
+
+and install this lib on the MicroPython device using the new `mip` package manager
+
+```python
+import mip
+mip.install("github:brainelectronics/micropython-nextion", version="develop")
 ```
 
 ### Manually

--- a/nextion/version.py
+++ b/nextion/version.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
-__version_info__ = ('0', '4', '0')
+__version_info__ = ('0', '14', '0')
 __version__ = '.'.join(__version_info__)
 __author__ = 'brainelectronics'

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
   "deps": [
     ["logging", "latest"]
   ],
-  "version": "0.4.0"
+  "version": "0.14.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "urls": [
+    ["nextion/__init__.py", "github:brainelectronics/micropython-nextion/nextion/__init__.py"],
+    ["nextion/common.py", "github:brainelectronics/micropython-nextion/nextion/common.py"],
+    ["nextion/const.py", "github:brainelectronics/micropython-nextion/nextion/const.py"],
+    ["nextion/nextion_button.py", "github:brainelectronics/micropython-nextion/nextion/nextion_button.py"],
+    ["nextion/nextion_checkbox.py", "github:brainelectronics/micropython-nextion/nextion/nextion_checkbox.py"],
+    ["nextion/nextion_dual_state_button.py", "github:brainelectronics/micropython-nextion/nextion/nextion_dual_state_button.py"],
+    ["nextion/nextion_gauge.py", "github:brainelectronics/micropython-nextion/nextion/nextion_gauge.py"],
+    ["nextion/nextion_gpio.py", "github:brainelectronics/micropython-nextion/nextion/nextion_gpio.py"],
+    ["nextion/nextion_hardware.py", "github:brainelectronics/micropython-nextion/nextion/nextion_hardware.py"],
+    ["nextion/nextion_number.py", "github:brainelectronics/micropython-nextion/nextion/nextion_number.py"],
+    ["nextion/nextion_page.py", "github:brainelectronics/micropython-nextion/nextion/nextion_page.py"],
+    ["nextion/nextion_progressbar.py", "github:brainelectronics/micropython-nextion/nextion/nextion_progressbar.py"],
+    ["nextion/nextion_radio.py", "github:brainelectronics/micropython-nextion/nextion/nextion_radio.py"],
+    ["nextion/nextion_rtc.py", "github:brainelectronics/micropython-nextion/nextion/nextion_rtc.py"],
+    ["nextion/nextion_slider.py", "github:brainelectronics/micropython-nextion/nextion/nextion_slider.py"],
+    ["nextion/nextion_text.py", "github:brainelectronics/micropython-nextion/nextion/nextion_text.py"],
+    ["nextion/nextion_upload.py", "github:brainelectronics/micropython-nextion/nextion/nextion_upload.py"],
+    ["nextion/nextion_variable.py", "github:brainelectronics/micropython-nextion/nextion/nextion_variable.py"],
+    ["nextion/nextion_waveform.py", "github:brainelectronics/micropython-nextion/nextion/nextion_waveform.py"],
+    ["nextion/typing.py", "github:brainelectronics/micropython-nextion/nextion/typing.py"],
+    ["nextion/version.py", "github:brainelectronics/micropython-nextion/nextion/version.py"],
+  ],
+  "deps": [
+    ["logging", "latest"]
+  ],
+  "version": "0.4.0"
+}


### PR DESCRIPTION
This PR should fix #27 be introducing these changes:

- Providing a `package.json` file as required by mip
- Update the Readme file to include instructions for mip install
- Update existing WIFI instructions to include the `.active(True)` call