### PR TITLE
Publish package to PyPi as micropython-nextion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,14 +34,12 @@ jobs:
             --version_file nextion/version.py \
             --version_file_type py \
             --debug
-          # micropython-nextion is owned by someone else on test.pypi.org
-          # rename package only for this case
-          sed -i \
-            "s/name\='micropython-nextion'/name\='be-micropython-nextion'/" \
-            setup.py
           python setup.py sdist
+      - name: Test built package
+        # sdist call creates non twine conform "*.orig" files, remove them
+        run: |
           rm dist/*.orig
-        # sdist call create non conform twine files *.orig, remove them
+          twine check dist/*.tar.gz
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1.5
         with:

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,10 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
+## [0.15.3] - 2023-05-17
+### Fixed
+- Publish releases to PyPi again as `micropython-nextion`, see #35
+
 ## [0.15.2] - 2023-05-14
 ### Fixed
 - Logger import fixed, see #31
@@ -225,8 +229,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - [Example HMI file](examples/everything.HMI) to be used for all examples
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-nextion/compare/0.15.2...develop
+[Unreleased]: https://github.com/brainelectronics/micropython-nextion/compare/0.15.3...develop
 
+[0.15.3]: https://github.com/brainelectronics/micropython-nextion/tree/0.15.3
 [0.15.2]: https://github.com/brainelectronics/micropython-nextion/tree/0.15.2
 [0.15.1]: https://github.com/brainelectronics/micropython-nextion/tree/0.15.1
 [0.15.0]: https://github.com/brainelectronics/micropython-nextion/tree/0.15.0


### PR DESCRIPTION
### Fixed
- Publish releases to PyPi again as `micropython-nextion`, see #35
